### PR TITLE
Add `parachains_pot` for Relay Chain Runtime

### DIFF
--- a/runtime/kusama/src/lib.rs
+++ b/runtime/kusama/src/lib.rs
@@ -1127,7 +1127,9 @@ impl parachains_inclusion::Config for Runtime {
 	type RewardValidators = parachains_reward_points::RewardValidatorsWithEraPoints<Runtime>;
 }
 
-impl parachains_pot::Config for Runtime {}
+impl parachains_pot::Config for Runtime {
+	type RuntimeEvent = RuntimeEvent;
+}
 
 parameter_types! {
 	pub const ParasUnsignedPriority: TransactionPriority = TransactionPriority::max_value();
@@ -1450,6 +1452,9 @@ construct_runtime! {
 		Slots: slots::{Pallet, Call, Storage, Event<T>} = 71,
 		Auctions: auctions::{Pallet, Call, Storage, Event<T>} = 72,
 		Crowdloan: crowdloan::{Pallet, Call, Storage, Event<T>} = 73,
+
+		// Pot Related
+		Pot: parachains_pot::{Pallet, Storage, Event} = 80, 
 
 		// Pallet for sending XCM.
 		XcmPallet: pallet_xcm::{Pallet, Call, Storage, Event<T>, Origin, Config} = 99,

--- a/runtime/parachains/src/mock.rs
+++ b/runtime/parachains/src/mock.rs
@@ -17,7 +17,7 @@
 //! Mocks for all the traits.
 
 use crate::{
-	configuration, disputes, dmp, hrmp, inclusion, initializer, origin, paras, paras_inherent,
+	configuration, disputes, dmp, hrmp, pot, inclusion, initializer, origin, paras, paras_inherent,
 	scheduler, session_info, shared,
 	ump::{self, MessageId, UmpSink},
 	ParaId,
@@ -68,6 +68,7 @@ frame_support::construct_runtime!(
 		SessionInfo: session_info,
 		Disputes: disputes,
 		Babe: pallet_babe,
+		Pot: pot,
 	}
 );
 
@@ -221,7 +222,9 @@ impl crate::paras::Config for Test {
 	type NextSessionRotation = TestNextSessionRotation;
 }
 
-impl crate::pot::Config for Test {}
+impl crate::pot::Config for Test {
+	type RuntimeEvent = RuntimeEvent;
+}
 
 impl crate::dmp::Config for Test {}
 

--- a/runtime/parachains/src/pot.rs
+++ b/runtime/parachains/src/pot.rs
@@ -1,6 +1,4 @@
 use crate::configuration;
-use frame_support::pallet_prelude::*;
-use frame_system::pallet_prelude::*;
 use primitives::Id as ParaId;
 use sp_runtime::generic::PotVotesResult;
 
@@ -8,18 +6,32 @@ pub use pallet::*;
 
 #[frame_support::pallet]
 pub mod pallet {
+	
+	use frame_support::pallet_prelude::*;
+	use frame_system::pallet_prelude::*;
 	use super::*;
-
+	
 	#[pallet::pallet]
 	#[pallet::generate_store(pub(super) trait Store)]
 	#[pallet::without_storage_info]
 	pub struct Pallet<T>(_);
 
 	#[pallet::config]
-	pub trait Config: frame_system::Config + configuration::Config {}
+	pub trait Config: frame_system::Config + configuration::Config {
+		type RuntimeEvent: From<Event> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+	}
 
 	#[pallet::error]
 	pub enum Error<T> {}
+
+	#[pallet::event]
+	#[pallet::generate_deposit(pub(super) fn deposit_event)]
+	pub enum Event {
+		VoteCollected{
+			para: ParaId, 
+			vote: PotVotesResult,
+		},
+	}
 
 	#[pallet::storage]
 	pub type AggregatedPotVotes<T: Config> =
@@ -29,6 +41,12 @@ pub mod pallet {
 impl<T: Config> Pallet<T> {
 
 	pub(crate) fn aggregate_vote_result(para: ParaId, result: PotVotesResult) {
-		AggregatedPotVotes::<T>::insert(para, result);
+		AggregatedPotVotes::<T>::insert(&para, result.clone());
+		Self::deposit_event(
+			Event::VoteCollected { 
+				para: para, 
+				vote: result,
+			}
+		)
 	}
 }

--- a/runtime/polkadot/src/lib.rs
+++ b/runtime/polkadot/src/lib.rs
@@ -1289,7 +1289,9 @@ impl parachains_inclusion::Config for Runtime {
 	type RewardValidators = parachains_reward_points::RewardValidatorsWithEraPoints<Runtime>;
 }
 
-impl parachains_pot::Config for Runtime {}
+impl parachains_pot::Config for Runtime {
+	type RuntimeEvent = RuntimeEvent;
+}
 
 parameter_types! {
 	pub const ParasUnsignedPriority: TransactionPriority = TransactionPriority::max_value();
@@ -1570,6 +1572,9 @@ construct_runtime! {
 		Slots: slots::{Pallet, Call, Storage, Event<T>} = 71,
 		Auctions: auctions::{Pallet, Call, Storage, Event<T>} = 72,
 		Crowdloan: crowdloan::{Pallet, Call, Storage, Event<T>} = 73,
+
+		// Pot Related
+		Pot: parachains_pot::{Pallet, Storage, Event} = 80, 
 
 		// Pallet for sending XCM.
 		XcmPallet: pallet_xcm::{Pallet, Call, Storage, Event<T>, Origin, Config} = 99,

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -1051,7 +1051,9 @@ impl parachains_inclusion::Config for Runtime {
 	type RewardValidators = RewardValidators;
 }
 
-impl parachains_pot::Config for Runtime {}
+impl parachains_pot::Config for Runtime {
+	type RuntimeEvent = RuntimeEvent;
+}
 
 parameter_types! {
 	pub const ParasUnsignedPriority: TransactionPriority = TransactionPriority::max_value();
@@ -1458,6 +1460,9 @@ construct_runtime! {
 		Slots: slots::{Pallet, Call, Storage, Event<T>} = 71,
 		Auctions: auctions::{Pallet, Call, Storage, Event<T>} = 72,
 		Crowdloan: crowdloan::{Pallet, Call, Storage, Event<T>} = 73,
+
+		// Pot Related
+		Pot: parachains_pot::{Pallet, Storage, Event} = 80, 
 
 		// Pallet for sending XCM.
 		XcmPallet: pallet_xcm::{Pallet, Call, Storage, Event<T>, Origin, Config} = 99,


### PR DESCRIPTION
## Description
- `CandidateCommitment` 에 포함된 `PotVoteResult` 를 `Parachain-Inclusion` 단계에서 aggregate 하기 위해 `pot-for-parachains` 모듈 정의
- `parachain-inclusion-pallet` 은 Relay Chain 런타임에 반드시 포함되어야할 모듈이고 parachain inclusion 에 필요한 모든 모듈(pot 모듈 포함)에 tightly-coupled 돼있다

## Changes
- `Polkadot`, `Kusama` , `Rococo` 런타임에 `parachains_pot` impl(+ InfraBs 는 zombienet 테스트 후 추가 예정) 

## Related Issues
#16 