### PR TITLE
Fix test-runtime when cumulus build error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4840,6 +4840,7 @@ dependencies = [
  "infrablockspace-runtime-common",
  "infrablockspace-runtime-parachains",
  "log",
+ "pallet-assets",
  "pallet-authority-discovery",
  "pallet-authorship",
  "pallet-babe",

--- a/node/test/service/src/chain_spec.rs
+++ b/node/test/service/src/chain_spec.rs
@@ -117,6 +117,12 @@ fn infrablockspace_testnet_genesis(
 	const STASH: u128 = 100 * DOTS;
 
 	runtime::GenesisConfig {
+		assets: runtime::AssetsConfig {
+			assets: vec![],
+			metadata: vec![],
+			accounts: vec![],
+			..Default::default()
+		},
 		system: runtime::SystemConfig {
 			code: runtime::WASM_BINARY.expect("Wasm binary must be built for testing").to_vec(),
 			..Default::default()

--- a/runtime/infrablockspace/src/lib.rs
+++ b/runtime/infrablockspace/src/lib.rs
@@ -23,8 +23,8 @@
 use pallet_transaction_payment::CurrencyAdapter;
 use runtime_common::{
 	auctions, claims, crowdloan, impl_runtime_weights, impls::DealWithFees, paras_registrar,
-	paras_sudo_wrapper, prod_or_fast, slots, BlockHashCount, BlockLength,
-	SlowAdjustingFeeUpdate, pot as relay_pot,
+	paras_sudo_wrapper, pot as relay_pot, prod_or_fast, slots, BlockHashCount, BlockLength,
+	SlowAdjustingFeeUpdate,
 };
 
 use runtime_parachains::{
@@ -42,20 +42,20 @@ use beefy_primitives::crypto::{AuthorityId as BeefyId, Signature as BeefySignatu
 use frame_support::{
 	construct_runtime, parameter_types,
 	traits::{
+		tokens::fungibles::{Balanced, CreditOf},
 		AsEnsureOriginWithArg, ConstU128, ConstU32, EitherOfDiverse, InstanceFilter,
 		KeyOwnerProofSystem, LockIdentifier, PrivilegeCmp, WithdrawReasons,
-		tokens::fungibles::{CreditOf, Balanced},
 	},
 	weights::ConstantMultiplier,
 	PalletId, RuntimeDebug,
 };
 use frame_system::EnsureRoot;
-use pallet_infra_voting::SessionIndex;
 use pallet_grandpa::{fg_primitives, AuthorityId as GrandpaId};
 use pallet_im_online::sr25519::AuthorityId as ImOnlineId;
+use pallet_infra_asset_tx_payment::{FungiblesAdapter, HandleCredit};
+use pallet_infra_voting::SessionIndex;
 use pallet_session::historical as session_historical;
 use pallet_transaction_payment::{FeeDetails, RuntimeDispatchInfo};
-use pallet_infra_asset_tx_payment::{FungiblesAdapter, HandleCredit};
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use primitives::{
 	AccountId, AccountIndex, Balance, BlockNumber, CandidateEvent, CommittedCandidateReceipt,
@@ -66,13 +66,12 @@ use primitives::{
 use sp_core::OpaqueMetadata;
 use sp_mmr_primitives as mmr;
 use sp_runtime::{
-	create_runtime_str,
-	generic,
+	create_runtime_str, generic,
 	generic::{VoteAccountId, VoteWeight},
 	impl_opaque_keys,
 	traits::{
-		AccountIdLookup, BlakeTwo256, Block as BlockT, ConvertInto, Extrinsic as ExtrinsicT,
-		OpaqueKeys, SaturatedConversion, Verify, AccountIdConversion,
+		AccountIdConversion, AccountIdLookup, BlakeTwo256, Block as BlockT, ConvertInto,
+		Extrinsic as ExtrinsicT, OpaqueKeys, SaturatedConversion, Verify,
 	},
 	transaction_validity::{TransactionPriority, TransactionSource, TransactionValidity},
 	ApplyExtrinsicResult, KeyTypeId, Perbill, Percent, Permill,
@@ -413,7 +412,6 @@ impl pallet_session::historical::Config for Runtime {
 	type FullIdentification = ();
 	type FullIdentificationOf = FullIdentificationOf;
 }
-
 
 parameter_types! {
 	// Minimum 4 CENTS/byte
@@ -1075,7 +1073,7 @@ parameter_types! {
 	pub const TotalNumberOfValidators: u32 = 5;
 	pub const MinVotePointsThreshold: u32 = 1;
 	pub const SessionsPerEra: u32 = 5;
-	// Should be removed.	
+	// Should be removed.
 	pub const BondingDuration: u32 = 28;
 }
 
@@ -1267,7 +1265,7 @@ construct_runtime! {
 		System: frame_system::{Pallet, Call, Storage, Config, Event<T>} = 0,
 		Scheduler: pallet_scheduler::{Pallet, Call, Storage, Event<T>} = 1,
 		Preimage: pallet_preimage::{Pallet, Call, Storage, Event<T>} = 100,
-		
+
 		// IBS Support
 		InfraSystemTokenManager: pallet_infra_system_token_manager::{Pallet, Call, Storage, Config<T>, Event<T>} = 20,
 		InfraReward: parachains_infra_reward::{Pallet, Call, Storage, Event<T>} = 21,

--- a/runtime/test-runtime/Cargo.toml
+++ b/runtime/test-runtime/Cargo.toml
@@ -33,6 +33,7 @@ frame-election-provider-support = { git = "https://github.com/InfraBlockchain/in
 tx-pool-api = { package = "sp-transaction-pool", git = "https://github.com/InfraBlockchain/infra-substrate", branch = "master", default-features = false }
 block-builder-api = { package = "sp-block-builder", git = "https://github.com/InfraBlockchain/infra-substrate", branch = "master", default-features = false }
 
+pallet-assets = { git = "https://github.com/InfraBlockchain/infra-substrate", branch = "master", default-features = false }
 pallet-authority-discovery = { git = "https://github.com/InfraBlockchain/infra-substrate", branch = "master", default-features = false }
 pallet-authorship = { git = "https://github.com/InfraBlockchain/infra-substrate", branch = "master", default-features = false }
 pallet-babe = { git = "https://github.com/InfraBlockchain/infra-substrate", branch = "master", default-features = false }
@@ -84,6 +85,7 @@ only-staking = []
 runtime-metrics = ["infrablockspace-runtime-parachains/runtime-metrics", "sp-io/with-tracing"]
 
 std = [
+	"pallet-assets/std",
 	"authority-discovery-primitives/std",
 	"pallet-authority-discovery/std",
 	"bitvec/std",

--- a/runtime/test-runtime/src/lib.rs
+++ b/runtime/test-runtime/src/lib.rs
@@ -516,9 +516,10 @@ impl parachains_shared::Config for Runtime {}
 impl parachains_inclusion::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type DisputesHandler = ParasDisputes;
-	type RewardValidators = RewardValidatorsWithEraPoints<Runtime>;
+	type RewardValidators = RewardValidators;
 	type VotingManager = InfraVoting;
 	type SystemTokenManager = InfraSystemTokenManager;
+	type RewardAggregateHandler = InfraReward;
 }
 
 parameter_types! {

--- a/runtime/test-runtime/src/lib.rs
+++ b/runtime/test-runtime/src/lib.rs
@@ -513,6 +513,12 @@ impl parachains_configuration::Config for Runtime {
 
 impl parachains_shared::Config for Runtime {}
 
+pub struct RewardValidators;
+impl infrablockspace_runtime_parachains::inclusion::RewardValidators for RewardValidators {
+	fn reward_backing(_: impl IntoIterator<Item = ValidatorIndex>) {}
+	fn reward_bitfields(_: impl IntoIterator<Item = ValidatorIndex>) {}
+}
+
 impl parachains_inclusion::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type DisputesHandler = ParasDisputes;

--- a/runtime/test-runtime/src/lib.rs
+++ b/runtime/test-runtime/src/lib.rs
@@ -39,8 +39,12 @@ use beefy_primitives::crypto::{AuthorityId as BeefyId, Signature as BeefySignatu
 use frame_election_provider_support::{onchain, SequentialPhragmen};
 use frame_support::{
 	construct_runtime, parameter_types,
-	traits::{Everything, KeyOwnerProofSystem, WithdrawReasons},
+	traits::{
+		AsEnsureOriginWithArg, ConstU128, ConstU32, Everything, KeyOwnerProofSystem,
+		WithdrawReasons,
+	},
 };
+use frame_system::EnsureRoot;
 use infrablockspace_runtime_parachains::reward_points::RewardValidatorsWithEraPoints;
 use pallet_grandpa::{fg_primitives, AuthorityId as GrandpaId};
 use pallet_session::historical as session_historical;
@@ -305,7 +309,7 @@ impl pallet_session::Config for Runtime {
 	type ValidatorIdOf = pallet_staking::StashOf<Self>;
 	type ShouldEndSession = Babe;
 	type NextSessionRotation = Babe;
-	type SessionManager = InfraReward;
+	type SessionManager = InfraVoting;
 	type SessionHandler = <SessionKeys as OpaqueKeys>::KeyTypeIdProviders;
 	type Keys = SessionKeys;
 	type WeightInfo = ();

--- a/runtime/test-runtime/src/lib.rs
+++ b/runtime/test-runtime/src/lib.rs
@@ -173,6 +173,28 @@ parameter_types! {
 	pub storage ExpectedBlockTime: Moment = MILLISECS_PER_BLOCK;
 }
 
+type AssetId = u32;
+impl pallet_assets::Config for Runtime {
+	type RuntimeEvent = RuntimeEvent;
+	type Balance = Balance;
+	type AssetId = AssetId;
+	type AssetIdParameter = parity_scale_codec::Compact<AssetId>;
+	type Currency = Balances;
+	type CreateOrigin = AsEnsureOriginWithArg<frame_system::EnsureSigned<AccountId>>;
+	type ForceOrigin = EnsureRoot<AccountId>;
+	type AssetDeposit = ConstU128<2>;
+	type AssetAccountDeposit = ConstU128<2>;
+	type MetadataDepositBase = ConstU128<0>;
+	type MetadataDepositPerByte = ConstU128<0>;
+	type ApprovalDeposit = ConstU128<0>;
+	type StringLimit = ConstU32<20>;
+	type Freezer = ();
+	type Extra = ();
+	type CallbackHandle = ();
+	type WeightInfo = ();
+	type RemoveItemsLimit = ConstU32<1000>;
+}
+
 impl pallet_babe::Config for Runtime {
 	type EpochDuration = EpochDuration;
 	type ExpectedBlockTime = ExpectedBlockTime;
@@ -720,6 +742,7 @@ construct_runtime! {
 		ParasDisputes: parachains_disputes::{Pallet, Storage, Event<T>},
 
 		// Infra Related
+		Assets: pallet_assets::{Pallet, Call, Storage, Event<T>, Config<T>},
 		InfraVoting: pallet_infra_voting::{Pallet, Call, Storage, Event<T>},
 		InfraSystemTokenManager: pallet_infra_system_token_manager::{Pallet, Call, Storage, Config<T>, Event<T>},
 


### PR DESCRIPTION
## Description
When build in infra-cumulus, build-error occurs at the `test-runtime` part.
This is because cumulus references the test-runtime of the infra-relay-chain.

## Changes
- add an assest genesis config to the chain spec
- add RewardValidators and impl for it
- add reward pallet to parachains_inclusion::Config
- import some unimported moduels and change session manager type
- fix runtime error with adding asset pallet 
- bug fix related generic of the runtime

## Related Issues
- #31 