### PR TITLE
Modify the XCM config 

### DIFF
--- a/runtime/parachains/src/system_token_manager.rs
+++ b/runtime/parachains/src/system_token_manager.rs
@@ -199,13 +199,15 @@ pub mod pallet {
 	#[pallet::storage]
 	#[pallet::getter(fn allowed_system_token)]
 	/// Wrapped System token list used in parachains.
+	/// Key: (PalletIndex, ParaAssetId) of Wrapped System token. ParaId is omitted.
+	/// Value: (SystemTokenId)
 	pub(super) type AllowedSystemToken<T: Config> = StorageDoubleMap<
 		_,
 		Twox64Concat,
 		PalletIndex,
 		Twox64Concat,
 		ParaAssetId,
-		WrappedSystemTokenId,
+		SystemTokenId,
 		OptionQuery,
 	>;
 

--- a/xcm/xcm-executor/src/lib.rs
+++ b/xcm/xcm-executor/src/lib.rs
@@ -524,12 +524,11 @@ impl<Config: config::Config> XcmExecutor<Config> {
 				let origin = *self.origin_ref().ok_or(XcmError::BadOrigin)?;
 				// check whether we trust origin to teleport this asset to us via config trait.
 				for asset in assets.inner() {
-					// We only trust the origin to send us assets that they identify as their
-					// sovereign assets.
-					ensure!(
-						Config::IsTeleporter::contains(asset, &origin),
-						XcmError::UntrustedTeleportLocation
-					);
+					// temporarilly comment out the below ensure logic for accepting unconstrained teleporting asset.
+					// ensure!(
+					// 	Config::IsTeleporter::contains(asset, &origin),
+					// 	XcmError::UntrustedTeleportLocation
+					// );
 					// We should check that the asset can actually be teleported in (for this to be in error, there
 					// would need to be an accounting violation by one of the trusted chains, so it's unlikely, but we
 					// don't want to punish a possibly innocent chain/user).


### PR DESCRIPTION
### Summary
- remove ensure logic related in IsTeleporter for the flexibility of transferring tokens 
- Change type of AllowedSystemToken

### Describe your changes
- comment out ensure logic related in IsTeleporter
- change type of `Value`on AllowedSystemToken from WrappedSystemTokenId => SystemTokenId
```rust
pub(super) type AllowedSystemToken<T: Config> = StorageDoubleMap<
		_,
		Twox64Concat,
		PalletIndex,
		Twox64Concat,
		ParaAssetId,
		SystemTokenId,
		OptionQuery,
	>;
```

### Related issues
#36 