### PR TITLE
refactor: remove redundant codes in xcm configuration

### DIFF
--- a/runtime/infrablockspace/src/xcm_config.rs
+++ b/runtime/infrablockspace/src/xcm_config.rs
@@ -37,9 +37,8 @@ use xcm::latest::prelude::*;
 use xcm_builder::{
 	AccountId32Aliases, AllowExplicitUnpaidExecutionFrom, AllowSubscriptionsFrom,
 	AllowTopLevelPaidExecutionFrom, BackingToPlurality, ChildParachainAsNative,
-	ChildParachainConvertsVia, CurrencyAdapter as XcmCurrencyAdapter, FixedWeightBounds,
-	FungiblesAdapter, IsConcrete, LocalMint, MintLocation, NonLocalMint, ParentIsPreset,
-	SiblingParachainConvertsVia, SignedAccountId32AsNative, SignedToAccountId32,
+	ChildParachainConvertsVia, FixedWeightBounds, FungiblesAdapter, LocalMint, NonLocalMint,
+	ParentIsPreset, SiblingParachainConvertsVia, SignedAccountId32AsNative, SignedToAccountId32,
 	SovereignSignedViaLocation, TakeWeightCredit,
 };
 use xcm_executor::traits::WithOriginFilter;


### PR DESCRIPTION
# Summary 
- refactor xcm configuration of the infra-blockspace

# Describe your changes
- refactor: remove redundant types in xcm_config.rs
- hotfix: change type of the system_token_weight to u128

### Related Issues
#60 